### PR TITLE
Fix: remove extern crate declarations

### DIFF
--- a/service/src/error.rs
+++ b/service/src/error.rs
@@ -1,4 +1,4 @@
-extern crate json;
+use quick_error::quick_error;
 
 use json::JsonValue;
 

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -1,7 +1,3 @@
-extern crate actix_web;
-extern crate chrono;
-extern crate json;
-
 pub mod error;
 pub mod utils;
 
@@ -14,9 +10,6 @@ use std::time::Duration;
 use error::Error;
 use utils::json::JsonParams;
 use utils::time::DateRange;
-
-#[macro_use]
-extern crate quick_error;
 
 use values::{ID, ID_MIN};
 

--- a/src/animo/ops_manager.rs
+++ b/src/animo/ops_manager.rs
@@ -165,7 +165,6 @@ impl<'a,O:FromKVBytes<O>> Iterator for BetweenHeavyIterator<'a,O> {
 }
 
 impl OpsManager {
-
     pub(crate) fn ops_between_light<'a,O,F,T>(
         &self, s: &'a Snapshot, from: &'a F, till: &'a T
     ) -> BetweenLightIterator<'a,O>

--- a/src/hik/data/alert_item.rs
+++ b/src/hik/data/alert_item.rs
@@ -1,6 +1,6 @@
-
 use minidom::Element;
 use serde::{Deserialize, Serialize};
+use quick_error::quick_error;
 use crate::hik::data::event_type::EventIdentifier;
 
 #[derive(Debug, PartialEq, Eq, Deserialize, Serialize, Clone)]

--- a/src/hik/data/device_info.rs
+++ b/src/hik/data/device_info.rs
@@ -1,5 +1,6 @@
 use minidom::Element;
 use serde::{Deserialize, Serialize};
+use quick_error::quick_error;
 
 #[derive(Debug, PartialEq, Eq, Deserialize, Serialize, Clone)]
 pub struct DeviceInfo {

--- a/src/hik/data/triggers_parser.rs
+++ b/src/hik/data/triggers_parser.rs
@@ -1,5 +1,7 @@
 use minidom::Element;
 use serde::{Deserialize, Serialize};
+use quick_error::quick_error;
+
 use crate::hik::data::event_type::EventIdentifier;
 
 #[derive(Debug, PartialEq, Eq, Deserialize, Serialize, Clone)]

--- a/src/hik/error.rs
+++ b/src/hik/error.rs
@@ -1,5 +1,4 @@
-
-
+use quick_error::quick_error;
 
 pub type Result<T> = std::result::Result<T, Error>;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,3 @@
-#[macro_use]
-extern crate quick_error;
-
 mod auth;
 pub mod commutator;
 mod file;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,22 +1,3 @@
-extern crate core;
-
-#[macro_use]
-extern crate quick_error;
-extern crate actix;
-extern crate actix_web;
-extern crate chrono;
-extern crate csv;
-extern crate dbase;
-extern crate json;
-extern crate jsonwebtoken;
-extern crate reqwest;
-extern crate rkyv;
-extern crate rust_decimal;
-extern crate service;
-extern crate store;
-extern crate tracing;
-extern crate uuid;
-
 use crate::commutator::{Application, Commutator};
 use actix::{Actor, Addr};
 use actix_cors::Cors;

--- a/store/src/lib.rs
+++ b/store/src/lib.rs
@@ -1,9 +1,3 @@
-extern crate chrono;
-extern crate json;
-extern crate rust_decimal;
-extern crate service;
-extern crate uuid;
-
 use wh_storage::WHStorage;
 
 pub mod aggregations;

--- a/store/tests/get_aggregations_without_checkpoints.rs
+++ b/store/tests/get_aggregations_without_checkpoints.rs
@@ -1,7 +1,3 @@
-extern crate uuid;
-extern crate store;
-extern crate tempfile;
-
 use uuid::Uuid;
 use tempfile::TempDir;
 use store::error::WHError;

--- a/store/tests/key_to_data.rs
+++ b/store/tests/key_to_data.rs
@@ -1,6 +1,3 @@
-extern crate store;
-extern crate uuid;
-
 use store::elements::{dt, Batch};
 use uuid::Uuid;
 use store::check_date_store_batch::CheckDateStoreBatch;

--- a/store/tests/neg_balance_date_type_store_goods_id.rs
+++ b/store/tests/neg_balance_date_type_store_goods_id.rs
@@ -1,7 +1,3 @@
-extern crate uuid;
-extern crate tempfile;
-extern crate store;
-
 use uuid::Uuid;
 use tempfile::TempDir;
 use store::wh_storage::WHStorage;

--- a/store/tests/op_iter.rs
+++ b/store/tests/op_iter.rs
@@ -1,6 +1,3 @@
-extern crate store;
-extern crate rocksdb;
-
 use store::error::WHError;
 use tempfile::TempDir;
 use store::wh_storage::WHStorage;

--- a/store/tests/receive_change_op.rs
+++ b/store/tests/receive_change_op.rs
@@ -1,5 +1,3 @@
-extern crate store;
-
 use store::balance::{BalanceDelta, BalanceForGoods};
 use store::elements::{
   dt, AggregationStore, AgregationStoreGoods, Balance, Batch, InternalOperation, Mode, OpMutation,

--- a/store/tests/receive_ops.rs
+++ b/store/tests/receive_ops.rs
@@ -1,7 +1,3 @@
-extern crate tempfile;
-extern crate store;
-extern crate uuid;
-
 use tempfile::TempDir;
 use store::wh_storage::WHStorage;
 use store::elements::{dt, Batch, OpMutation, InternalOperation, Mode, Balance};

--- a/store/tests/zero_balance_date_type_store_goods_id.rs
+++ b/store/tests/zero_balance_date_type_store_goods_id.rs
@@ -1,7 +1,3 @@
-extern crate uuid;
-extern crate tempfile;
-extern crate store;
-
 use uuid::Uuid;
 use tempfile::TempDir;
 use store::wh_storage::WHStorage;

--- a/tests/app_from_csv.rs
+++ b/tests/app_from_csv.rs
@@ -1,7 +1,3 @@
-extern crate actix_web;
-extern crate nae_backend;
-extern crate structopt;
-
 mod test_init;
 
 use test_init::init;


### PR DESCRIPTION
`extern crate` declarations are obsolete and not needed anymore in modern Rust